### PR TITLE
Feature: Support multiple Virtual Hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM nginx:latest
 VOLUME /etc/ssl/private
 
 RUN apt-get update && \
-    apt-get install -y openssl
+    apt-get install -y openssl ruby --no-install-recommends
 
-ADD artifacts/nginx.template /etc/nginx/conf.d/nginx.template
+ADD artifacts/nginx.template /templates/
+ADD artifacts/vhosts.yml /templates/
 
 ADD artifacts/bin/start_proxy /usr/sbin/
 RUN chmod +x /usr/sbin/start_proxy

--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ services:
        - 443:443
 ```
 
+### Defining multiple virtual hosts
+If you would like to define multiple virtual hosts, you will need to create a YML file and mount it to `/config/vhosts.yml`. Please note: If you do this, *ALL* vhost-related environment variables will be ignored.
+
+```yaml
+---
+vhosts:
+  - server_name: my-first-app.com
+    proxied_app_url: http://app1
+    ssl_cert_filename: app1-cert.pem
+    ssl_cert_key_filename: app1-key.pem
+    http_port: # Optional, Defaults to 80
+    https_port: # Optional, Defaults to 443
+  
+  - server_name: my-second-app.com
+    proxied_app_url: http://app2
+    ssl_cert_filename: app2-cert.pem
+    ssl_cert_key_filename: app2-key.pem
+    http_port: # Optional, Defaults to 80
+    https_port: # Optional, Defaults to 443
+```
+
 ## License
 
 The image is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/artifacts/bin/start_proxy
+++ b/artifacts/bin/start_proxy
@@ -1,59 +1,46 @@
-#!/bin/bash
-set -eo pipefail
+#!/usr/bin/env ruby
+user_defined_config_file_path = '/config/vhosts.yml'
+template_config_file_path = '/templates/vhosts.yml'
+nginx_template_file_path = '/templates/nginx.template'
+ssl_certificate_base_path = '/etc/ssl/private'
 
-dh_parameters_path=/etc/ssl/private/dhparam.pem
+require 'yaml'
+require 'erb'
 
-# Default values
-default_http_port=80
-default_https_port=443
-default_ssl_cert_filename=cert.pem
-default_ssl_cert_key_filename=key.pem
+yaml_file = File.exists?(user_defined_config_file_path) ? user_defined_config_file_path : template_config_file_path
 
-# Use default values rather than ENV vars, if not present
-export HTTP_PORT=${HTTP_PORT:-$default_http_port}
-export HTTPS_PORT=${HTTPS_PORT:-$default_https_port}
-export SSL_CERT_FILENAME=${SSL_CERT_FILENAME:-$default_ssl_cert_filename}
-export SSL_CERT_KEY_FILENAME=${SSL_CERT_KEY_FILENAME:-$default_ssl_cert_key_filename}
+yaml_content = YAML.load(ERB.new(File.read(yaml_file)).result)
 
+yaml_content['vhosts'].each do |vhost|
+  server_name = vhost['server_name']
+  proxied_app_url = vhost['proxied_app_url']
+  ssl_cert_filename = vhost['ssl_cert_filename'] || 'cert.pem'
+  ssl_cert_key_filename = vhost['ssl_cert_key_filename'] || 'key.pem'
+  http_port = vhost['http_port'] || 80
+  https_port = vhost['https_port'] || 443
+  dh_param_filename = 'dhparam.pem'
 
-# Make sure the DH parameters and certificate files are accessible
-if [[ ! -f ${dh_parameters_path} ]]; then
-  cat <<EOF
-ERROR: Diffie Hellman parameters not found at ${dh_parameters_path}.
-Please generate DH parameters and mount them at the aforementioned path.
-e.g. openssl dhparam -out /path/to/mounted/directory/dhparam.pem 4096
-EOF
-  exit 1
-fi
+  abort 'ERROR: A vhost must contain a `server_name`. Please check your configuration.' if server_name.nil?
+  abort "ERROR: vhost `#{server_name}` does not define a `proxied_app_url`. Please check your configuration." if proxied_app_url.nil?
 
-declare -a required_cert_files=(${SSL_CERT_FILENAME} ${SSL_CERT_KEY_FILENAME})
-
-for file in "${required_cert_files[@]}"
-do
-  cert_base_dir=/etc/ssl/private
-
-   if [[ ! -f "${cert_base_dir}/${file}" ]]; then
-    cat <<EOF
-    ERROR: ${file} does not exist in ${cert_base_dir}.
-    Please make sure this file exists and is in a directory that is mounted to the aforementioned path.
-EOF
-    exit 1
-   fi
-done
-
-# Make sure that the required environment variables are set
-declare -a required_env_variables=("SERVER_NAME" "PROXIED_APP_URL")
-
-for env_var in "${required_env_variables[@]}"; do  
-  if [[ -z "${!env_var}" ]]; then
-    echo "ERROR: The '${env_var}' environment variable must be set."
-    exit 1
-  fi
-done
+  [ssl_cert_filename, ssl_cert_key_filename, dh_param_filename].each do |file|
+    absolute_path = File.join(ssl_certificate_base_path, file)
+    
+    abort "ERROR: #{absolute_path} does not exist. Please check your configuration." unless File.exists?(absolute_path)
+  end
 
 
-# Deploy config
-envsubst '\$HTTP_PORT \$HTTPS_PORT \$SERVER_NAME \$PROXIED_APP_URL \$SSL_CERT_FILENAME \$SSL_CERT_KEY_FILENAME' < /etc/nginx/conf.d/nginx.template > /etc/nginx/conf.d/default.conf
+  # Build an NGinx config file using the NGinx template
+  nginx_config_content = File.open(nginx_template_file_path, 'r').read
+  nginx_config_content.gsub!('{SERVER_NAME}', server_name)
+  nginx_config_content.gsub!('{PROXIED_APP_URL}', proxied_app_url)
+  nginx_config_content.gsub!('{SSL_CERT_FILENAME}', ssl_cert_filename)
+  nginx_config_content.gsub!('{SSL_CERT_KEY_FILENAME}', ssl_cert_key_filename)
+  nginx_config_content.gsub!('{HTTP_PORT}', http_port.to_s)
+  nginx_config_content.gsub!('{HTTPS_PORT}', https_port.to_s)
 
-# Run NGinx
-exec nginx -g 'daemon off;'
+  File.write("/etc/nginx/conf.d/#{server_name}.conf", nginx_config_content)
+end
+
+# Start NGinx
+exec "nginx -g 'daemon off;'"

--- a/artifacts/nginx.template
+++ b/artifacts/nginx.template
@@ -1,21 +1,21 @@
 server {
-  listen $HTTP_PORT;
-  listen [::]:$HTTP_PORT;
-  server_name $SERVER_NAME;
+  listen {HTTP_PORT};
+  listen [::]:{HTTP_PORT};
+  server_name {SERVER_NAME};
 
   return 301 https://$host$request_uri;
 }
 
 server {
-  listen $HTTPS_PORT ssl;
-  listen [::]:$HTTPS_PORT ssl;
-  server_name $SERVER_NAME;
+  listen {HTTPS_PORT} ssl;
+  listen [::]:{HTTPS_PORT} ssl;
+  server_name {SERVER_NAME};
 
   error_log /dev/stdout info;
   access_log /dev/stdout main;
 
-  ssl_certificate     /etc/ssl/private/$SSL_CERT_FILENAME;
-  ssl_certificate_key /etc/ssl/private/$SSL_CERT_KEY_FILENAME;
+  ssl_certificate     /etc/ssl/private/{SSL_CERT_FILENAME};
+  ssl_certificate_key /etc/ssl/private/{SSL_CERT_KEY_FILENAME};
 
   # Use strong config, as outlined on https://cipherli.st/
   ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
@@ -41,7 +41,7 @@ server {
     gzip_vary on;
     gzip_comp_level  6;
 
-    proxy_pass  $PROXIED_APP_URL;
+    proxy_pass  {PROXIED_APP_URL};
     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;

--- a/artifacts/vhosts.yml
+++ b/artifacts/vhosts.yml
@@ -1,0 +1,8 @@
+---
+vhosts:
+  - server_name: <%= ENV['SERVER_NAME'] %>
+    proxied_app_url: <%= ENV['PROXIED_APP_URL'] %>
+    ssl_cert_filename: <%= ENV['SSL_CERT_FILENAME'] %>
+    ssl_cert_key_filename: <%= ENV['SSL_CERT_KEY_FILENAME'] %>
+    http_port: <%= ENV['HTTP_PORT'] %>
+    https_port: <%= ENV['HTTPS_PORT'] %>


### PR DESCRIPTION
Resolves https://github.com/xtrasimplicity/docker-nginx-proxy/issues/1

> Currently, it is not possible for a single proxy server to handle multiple VHosts, which means this image can't be used as a centralised load balancer for multiple applications.

> To resolve this, I'm thinking of adding the ability to optionally define the container configuration as a YAML or JSON file, in addition to the existing environment variables. When a YAML/JSON file is specified, the environment variables should be ignored completely.

> As with the current setup, this configuration file should be parsed on container start up.