### PR TITLE
Exclude specific headers from being injected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ vhosts:
     https_port: # Optional, Defaults to 443
     nginx_directives: # Optional, additional NGinx directives, in `Key: value` format.
       client_max_body_size: 0
-  
+    headers_to_exclude: # Optional, an array of headers to be excluded from the generated NGinx config file. Note: Headers added using `nginx_directives` are not excluded.
+ 
   - server_name: my-second-app.com
     proxied_app_url: http://app2
     ssl_cert_filename: app2-cert.pem

--- a/artifacts/bin/start_proxy
+++ b/artifacts/bin/start_proxy
@@ -26,6 +26,7 @@ yaml_content['vhosts'].each do |vhost|
       "#{key} #{value};"
     end
   end
+  headers_to_exclude = vhost['headers_to_exclude'].to_a
 
   abort 'ERROR: A vhost must contain a `server_name`. Please check your configuration.' if server_name.nil?
   abort "ERROR: vhost `#{server_name}` does not define a `proxied_app_url`. Please check your configuration." if proxied_app_url.nil?
@@ -56,6 +57,10 @@ yaml_content['vhosts'].each do |vhost|
   nginx_config_content.gsub!('{SSL_CERT_KEY_FILENAME}', ssl_cert_key_filename)
   nginx_config_content.gsub!('{HTTP_PORT}', http_port.to_s)
   nginx_config_content.gsub!('{HTTPS_PORT}', https_port.to_s)
+
+  headers_to_exclude.each do |header|
+    nginx_config_content.gsub!(/add_header #{header} .*/i, '')
+  end
 
   nginx_config_content.gsub!('{ADDITIONAL_NGINX_DIRECTIVES}', additional_nginx_directives.join("\n"))
 

--- a/test/features/defining_hosts_with_vhosts_yml.feature
+++ b/test/features/defining_hosts_with_vhosts_yml.feature
@@ -32,3 +32,24 @@ Feature: Defining virtual hosts with a `vhosts.yml` file
     proxy_set_header X-Custom-Header-A "valueA";
     proxy_set_header X-Custom-Header-B "valueB";
     """
+
+  Scenario: Excluding headers from the resulting NGinx config.
+    Given a file named "/config/vhosts.yml" with:
+    """
+    ---
+    vhosts:
+      - server_name: localhost.127.0.0.1.xip.io
+        proxied_app_url: http:/app
+        headers_to_exclude:
+          - X-Frame-Options
+          - X-XSS-Protection
+    """
+    When I start the proxy server
+    Then the file "/etc/nginx/conf.d/localhost.127.0.0.1.xip.io.conf" should not contain:
+    """
+    add_header X-Frame-Options
+    """
+    And the file "/etc/nginx/conf.d/localhost.127.0.0.1.xip.io.conf" should not contain:
+    """
+    add_header X-XSS-Protection
+    """

--- a/test/features/step_definitions/proxy_steps.rb
+++ b/test/features/step_definitions/proxy_steps.rb
@@ -16,3 +16,9 @@ Then("the file {string} should contain:") do |path, expected_content|
 
   expect(actual_content).to include(expected_content)
 end
+
+Then("the file {string} should not contain:") do |path, expected_content|
+  actual_content = File.read(path)
+
+  expect(actual_content).not_to include(expected_content)
+end


### PR DESCRIPTION
Added the ability to exclude specific headers from being injected into the resultant NGinx configuration files, by adding an array of header names to the `headers_to_exclude` option for each vhost.

e.g.
```yaml
---
vhosts:
  - server_name: my-first-app.com
    proxied_app_url: http://app1
    ssl_cert_filename: app1-cert.pem
    ssl_cert_key_filename: app1-key.pem
    http_port: # Optional, Defaults to 80
    https_port: # Optional, Defaults to 443
    headers_to_exclude:
      - X-XSS-Protection
      - X-Frame-Options
      - X-Content-Type-Options
      - Strict-Transport-Security
```